### PR TITLE
Fix discrepancy between indexes in a proxy list

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.4.1 (not released)
+--------------------
+
+- fix index handling in get_absolute_bounding_box_of_attribute method in
+  a LineProxyList
+
 0.4 (2014-12-11)
 ----------------
 

--- a/redbaron.py
+++ b/redbaron.py
@@ -1565,6 +1565,13 @@ class LineProxyList(ProxyList):
             else:
                 self.node_list.pop(i)
 
+    def get_absolute_bounding_box_of_attribute(self, index):
+        if index >= len(self.data) or index < 0:
+            raise IndexError()
+        index = self[index].index_on_parent
+        path = self.path().to_baron_path() + [index]
+        return baron.path.path_to_bounding_box(self.root.fst(), path)
+
 
 class DecoratorsLineProxyList(LineProxyList):
     def _convert_input_to_node_object_list(self, value, parent, on_attribute):

--- a/tests/test_bounding_box.py
+++ b/tests/test_bounding_box.py
@@ -79,3 +79,64 @@ def test_bounding_box_empty():
     red = RedBaron("a()")
     assert ((1, 3), (1, 2)) == red.atomtrailers.value[1].value.absolute_bounding_box
 
+
+RED = RedBaron("""\
+class A:
+    ''' Class docstring
+
+    Class description
+    '''
+    attrA = [ a,
+         b,
+            c,
+               d]
+
+    def a(self):
+        ''' Function a docstring
+
+        Function description
+        '''
+        pass
+
+    attrB = valB
+
+    @myDecorator
+    def b(self):
+        ''' Function b docstring
+
+        Function description
+        '''
+        pass
+
+    attrC = [ a,
+         b,
+            c,
+               d]\
+""")
+
+
+def test_bounding_box_with_proxy_list():
+    assert ((1, 1), (32, 0)) == RED.absolute_bounding_box
+    assert ((1, 1), (32, 0)) == RED.class_.absolute_bounding_box
+    assert ((2, 5), (5, 7)) == RED.class_.value[0].absolute_bounding_box
+    assert ((6, 5), (9, 17)) == RED.class_.value[1].absolute_bounding_box
+    assert ((9, 18), (10, 0)) == RED.class_.value[2].absolute_bounding_box
+    assert ((11, 5), (18, 4)) == RED.class_.value[3].absolute_bounding_box
+    assert ((18, 5), (18, 16)) == RED.class_.value[4].absolute_bounding_box
+    assert ((18, 17), (19, 0)) == RED.class_.value[5].absolute_bounding_box
+    assert ((20, 5), (28, 4)) == RED.class_.value[6].absolute_bounding_box
+    assert ((28, 5), (31, 17)) == RED.class_.value[7].absolute_bounding_box
+
+
+def test_bounding_box_of_attribute_with_proxy_list():
+    assert ((1, 1), (32, 0)) == RED.absolute_bounding_box
+    assert ((1, 1), (32, 0)) == RED.class_.absolute_bounding_box
+    assert ((2, 5), (5, 7)) == RED.class_.value.get_absolute_bounding_box_of_attribute(0)
+    assert ((6, 5), (9, 17)) == RED.class_.value.get_absolute_bounding_box_of_attribute(1)
+    assert ((9, 18), (10, 0)) == RED.class_.value.get_absolute_bounding_box_of_attribute(2)
+    assert ((11, 5), (18, 4)) == RED.class_.value.get_absolute_bounding_box_of_attribute(3)
+    assert ((18, 5), (18, 16)) == RED.class_.value.get_absolute_bounding_box_of_attribute(4)
+    assert ((18, 17), (19, 0)) == RED.class_.value.get_absolute_bounding_box_of_attribute(5)
+    assert ((20, 5), (28, 4)) == RED.class_.value.get_absolute_bounding_box_of_attribute(6)
+    assert ((28, 5), (31, 17)) == RED.class_.value.get_absolute_bounding_box_of_attribute(7)
+

--- a/tests/test_bounding_box.py
+++ b/tests/test_bounding_box.py
@@ -126,6 +126,8 @@ def test_bounding_box_with_proxy_list():
     assert ((18, 17), (19, 0)) == RED.class_.value[5].absolute_bounding_box
     assert ((20, 5), (28, 4)) == RED.class_.value[6].absolute_bounding_box
     assert ((28, 5), (31, 17)) == RED.class_.value[7].absolute_bounding_box
+    with pytest.raises(IndexError):
+        RED.class_.value[8]
 
 
 def test_bounding_box_of_attribute_with_proxy_list():
@@ -139,4 +141,6 @@ def test_bounding_box_of_attribute_with_proxy_list():
     assert ((18, 17), (19, 0)) == RED.class_.value.get_absolute_bounding_box_of_attribute(5)
     assert ((20, 5), (28, 4)) == RED.class_.value.get_absolute_bounding_box_of_attribute(6)
     assert ((28, 5), (31, 17)) == RED.class_.value.get_absolute_bounding_box_of_attribute(7)
+    with pytest.raises(IndexError):
+        RED.class_.value.get_absolute_bounding_box_of_attribute(8)
 


### PR DESCRIPTION
There is a discrepancy between the index of a proxy list and the
expected index in some functions.