### PR TITLE
[mod] show expected insert behaviour

### DIFF
--- a/tests/test_bounding_box.py
+++ b/tests/test_bounding_box.py
@@ -121,11 +121,13 @@ def test_bounding_box_with_proxy_list():
     assert ((2, 5), (5, 7)) == RED.class_.value[0].absolute_bounding_box
     assert ((6, 5), (9, 17)) == RED.class_.value[1].absolute_bounding_box
     assert ((9, 18), (10, 0)) == RED.class_.value[2].absolute_bounding_box
-    assert ((11, 5), (18, 4)) == RED.class_.value[3].absolute_bounding_box
-    assert ((18, 5), (18, 16)) == RED.class_.value[4].absolute_bounding_box
-    assert ((18, 17), (19, 0)) == RED.class_.value[5].absolute_bounding_box
-    assert ((20, 5), (28, 4)) == RED.class_.value[6].absolute_bounding_box
-    assert ((28, 5), (31, 17)) == RED.class_.value[7].absolute_bounding_box
+    assert ((11, 5), (16, 12)) == RED.class_.value[3].absolute_bounding_box
+    assert ((16, 13), (17, 0)) == RED.class_.value[4].absolute_bounding_box
+    assert ((18, 5), (18, 16)) == RED.class_.value[5].absolute_bounding_box
+    assert ((18, 17), (19, 0)) == RED.class_.value[6].absolute_bounding_box
+    assert ((20, 5), (26, 12)) == RED.class_.value[7].absolute_bounding_box
+    assert ((26, 13), (27, 0)) == RED.class_.value[8].absolute_bounding_box
+    assert ((28, 5), (31, 17)) == RED.class_.value[9].absolute_bounding_box
     with pytest.raises(IndexError):
         RED.class_.value[8]
 
@@ -136,10 +138,12 @@ def test_bounding_box_of_attribute_with_proxy_list():
     assert ((2, 5), (5, 7)) == RED.class_.value.get_absolute_bounding_box_of_attribute(0)
     assert ((6, 5), (9, 17)) == RED.class_.value.get_absolute_bounding_box_of_attribute(1)
     assert ((9, 18), (10, 0)) == RED.class_.value.get_absolute_bounding_box_of_attribute(2)
-    assert ((11, 5), (18, 4)) == RED.class_.value.get_absolute_bounding_box_of_attribute(3)
-    assert ((18, 5), (18, 16)) == RED.class_.value.get_absolute_bounding_box_of_attribute(4)
-    assert ((18, 17), (19, 0)) == RED.class_.value.get_absolute_bounding_box_of_attribute(5)
-    assert ((20, 5), (28, 4)) == RED.class_.value.get_absolute_bounding_box_of_attribute(6)
-    assert ((28, 5), (31, 17)) == RED.class_.value.get_absolute_bounding_box_of_attribute(7)
+    assert ((11, 5), (16, 12)) == RED.class_.value.get_absolute_bounding_box_of_attribute(3)
+    assert ((16, 13), (17, 0)) == RED.class_.value.get_absolute_bounding_box_of_attribute(4)
+    assert ((18, 5), (18, 16)) == RED.class_.value.get_absolute_bounding_box_of_attribute(5)
+    assert ((18, 17), (19, 0)) == RED.class_.value.get_absolute_bounding_box_of_attribute(6)
+    assert ((20, 5), (26, 12)) == RED.class_.value.get_absolute_bounding_box_of_attribute(7)
+    assert ((26, 13), (27, 0)) == RED.class_.value.get_absolute_bounding_box_of_attribute(8)
+    assert ((28, 5), (31, 17)) == RED.class_.value.get_absolute_bounding_box_of_attribute(9)
     with pytest.raises(IndexError):
         RED.class_.value.get_absolute_bounding_box_of_attribute(8)

--- a/tests/test_insert.py
+++ b/tests/test_insert.py
@@ -40,8 +40,8 @@ def test_insert_with_class_1(red):
     assert red.dumps() == """\
 class A:
     pass
-
 a = 1
+
 class B:
     pass
 """
@@ -55,9 +55,9 @@ def test_insert_with_class_2(red):
 class A:
     pass
 
+a = 1
 class B:
     pass
-a = 1
 """
 
 
@@ -73,3 +73,88 @@ class B:
     pass
 a = 1
 """
+
+
+def test_insert_with_class_after(red):
+    red.insert(4, "a = 1")
+
+    print(red.dumps())
+    assert red.dumps() == """\
+class A:
+    pass
+
+class B:
+    pass
+a = 1
+"""
+
+
+def test_insert_with_class_neg_1(red):
+    red.insert(-1, "a = 1")
+
+    print(red.dumps())
+    assert red.dumps() == """\
+class A:
+    pass
+
+class B:
+    pass
+a = 1
+"""
+
+
+def test_insert_with_class_neg_2(red):
+    red.insert(-2, "a = 1")
+
+    print(red.dumps())
+    assert red.dumps() == """\
+class A:
+    pass
+
+a = 1
+class B:
+    pass
+"""
+
+
+def test_insert_with_class_neg_3(red):
+    red.insert(-3, "a = 1")
+
+    print(red.dumps())
+    assert red.dumps() == """\
+class A:
+    pass
+a = 1
+
+class B:
+    pass
+"""
+
+
+def test_insert_with_class_neg_4(red):
+    red.insert(-4, "a = 1")
+
+    print(red.dumps())
+    assert red.dumps() == """\
+a = 1
+class A:
+    pass
+
+class B:
+    pass
+"""
+
+
+def test_insert_with_class_neg_before(red):
+    red.insert(-5, "a = 1")
+
+    print(red.dumps())
+    assert red.dumps() == """\
+a = 1
+class A:
+    pass
+
+class B:
+    pass
+"""
+


### PR DESCRIPTION
The problem is that the second '\n' after a class is still part of the
class.

At first glance, the fix should happen in baron. In [indentation_marker.py#50](https://github.com/Psycojoker/baron/blob/master/baron/indentation_marker.py#L50) and [indentation_marker.py#L74](https://github.com/Psycojoker/baron/blob/master/baron/indentation_marker.py#L74).