### PR TITLE
py3: replace "print x" with "print(x)"

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -19,7 +19,7 @@ RedBaron is very simple to use, you just need to import it and feed him with a s
 
     from redbaron import RedBaron
 
-    red = RedBaron("print 'hello world!'")
+    red = RedBaron("print('hello world!')")
 
 But what you should be really doing is using RedBaron directly into a shell (I
 recommend `IPython <http://ipython.org/>`_ but
@@ -38,7 +38,7 @@ for it, like BeautifulSoup.
 .. ipython:: python
 
     from redbaron import RedBaron
-    red = RedBaron("hello = 'Hello World!'\nprint hello")
+    red = RedBaron("hello = 'Hello World!'\nprint(hello)")
     red
 
 As you can see, when displayed in a shell, a RedBaron instance renders to the actual
@@ -111,10 +111,10 @@ You can read their documentation using the :file:`?` magic of ipython:
 
 .. ipython:: python
 
-    print red[0].names.__doc__  # you can do "red[0].names?" in IPython shell
+    print(red[0].names.__doc__)  # you can do "red[0].names?" in IPython shell
     red[0].names()
 
-    print red[0].modules.__doc__
+    print(red[0].modules.__doc__)
     red[0].modules()
 
 If you come with cool helpers, don't hesitate to propose them in a `pull
@@ -169,7 +169,7 @@ attributes):
 
     In [3]: red[0].value
 
-* node attributes, which are other nodes. They are shown with a :file:`->` followed by the name of the other node 
+* node attributes, which are other nodes. They are shown with a :file:`->` followed by the name of the other node
   at the next line in :file:`.help()`. :file:`.target` and :file:`.value` here for example.
 
 .. ipython::
@@ -180,7 +180,7 @@ attributes):
 
     In [21]: red[0].target.help()
 
-* nodelist attributes, which are lists of other nodes. They are shown with a :file:`->` followed by a series of names 
+* nodelist attributes, which are lists of other nodes. They are shown with a :file:`->` followed by a series of names
   of the other nodes starting with a :file:`*` for every item of the list. :file:`.value` here for example:
 
 .. ipython::

--- a/docs/dotproxylist.rst
+++ b/docs/dotproxylist.rst
@@ -145,7 +145,7 @@ __iter__
 
     red
     for i in red[0].value:
-        print i.dumps()
+        print(i.dumps())
 
 __getslice__
 ~~~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -114,7 +114,7 @@ And let's see the result of our work:
 
 .. ipython:: python
 
-    print red.dumps()
+    print(red.dumps())
 
 Table of content
 ----------------

--- a/docs/lineproxylist.rst
+++ b/docs/lineproxylist.rst
@@ -37,7 +37,7 @@ insert
 .. ipython:: python
 
     red
-    red[0].value.insert(1, "print caribou")
+    red[0].value.insert(1, "print(caribou)")
     red
     red[0].value
 
@@ -145,7 +145,7 @@ __iter__
 
     red
     for i in red[0].value:
-        print i.dumps()
+        print(i.dumps())
 
 __getslice__
 ~~~~~~~~~~~~

--- a/docs/nodes_reference.rst
+++ b/docs/nodes_reference.rst
@@ -1090,14 +1090,14 @@ A node representing a print statement.
 
 .. ipython:: python
 
-    RedBaron("print stuff")[0].help(deep=True)
+    RedBaron("print(stuff)")[0].help(deep=True)
 
 SetAttr
 -------
 
 .. ipython:: python
 
-    red = RedBaron("print stuff")
+    red = RedBaron("print(stuff)")
     red
     red[0].destination = "some_file"
     red

--- a/docs/other.rst
+++ b/docs/other.rst
@@ -86,31 +86,31 @@ if you want to iterate on the neighbours of the node.
 
     In [42]: list = red[0]
 
-    In [42]: print list.next
-    In [42]: print list.previous
+    In [42]: print(list.next)
+    In [42]: print(list.previous)
 
     In [42]: list.help()
-    In [42]: print list.value[0]
-    In [42]: print list.value[0].next
-    In [42]: print list.value[0].previous
-    In [42]: print list.value[2]
-    In [42]: print list.value[2].next
-    In [42]: print list.value[2].previous
+    In [42]: print(list.value[0])
+    In [42]: print(list.value[0].next)
+    In [42]: print(list.value[0].previous)
+    In [42]: print(list.value[2])
+    In [42]: print(list.value[2].next)
+    In [42]: print(list.value[2].previous)
 
     In [42]: assign = red[2]
 
     In [42]: assign.help()
-    In [42]: print assign.target.next
-    In [42]: print assign.target.previous
+    In [42]: print(assign.target.next)
+    In [42]: print(assign.target.previous)
 
     In [42]: list.value[2].help(deep=1)
-    In [42]: print [x for x list.value[2].next_generator()]
-    In [42]: print [x for x list.value[2].previous_generator()]
+    In [42]: print([x for x list.value[2].next_generator()])
+    In [42]: print([x for x list.value[2].previous_generator()])
     In [42]: list.value.help(deep=0)
-    In [42]: print [x for x list.value.next_generator()]
-    In [42]: print [x for x list.value.previous_generator()]
-    In [42]: print [x for x assign.target.next_generator()]
-    In [42]: print [x for x assign.target.previous_generator()]
+    In [42]: print([x for x list.value.next_generator()])
+    In [42]: print([x for x list.value.previous_generator()])
+    In [42]: print([x for x assign.target.next_generator()])
+    In [42]: print([x for x assign.target.previous_generator()])
 
 .root
 -----
@@ -392,7 +392,7 @@ node you've just got via query. Those helpers are here for that:
 
 .. ipython:: python
 
-    red = RedBaron("foo = 42\nprint 'bar'\n")
+    red = RedBaron("foo = 42\nprint('bar')\n")
     red
     red.print_.insert_before("baz")
     red
@@ -405,7 +405,7 @@ than one line after or before:
 
 .. ipython:: python
 
-    red = RedBaron("foo = 42\nprint 'bar'\n")
+    red = RedBaron("foo = 42\nprint('bar')\n")
     red
     red.print_.insert_before("baz", offset=1)
     red

--- a/docs/proxy_list.rst
+++ b/docs/proxy_list.rst
@@ -217,7 +217,7 @@ __iter__
 
     red
     for i in red[0].value:
-        print i.dumps()
+        print(i.dumps())
 
 __getslice__
 ~~~~~~~~~~~~

--- a/docs/tuto.rst
+++ b/docs/tuto.rst
@@ -76,7 +76,7 @@ that has "_formatting" in its name is formatting related):
     import json
 
     red = RedBaron("1+2")
-    print json.dumps(red.fst(), indent=4)  # json.dumps is used for pretty printing
+    print(json.dumps(red.fst(), indent=4))  # json.dumps is used for pretty printing
 
 Use it in a shell
 -----------------
@@ -88,7 +88,7 @@ selected source code, so you'll have a direct idea of what you are working on:
 
 .. ipython:: python
 
-    red = RedBaron("stuff = 1 + 2\nprint 'Hello', stuff")
+    red = RedBaron("stuff = 1 + 2\nprint(stuff)")
     red
 
 You might notice the :file:`0` and the :file:`1` on the left: those are the
@@ -274,7 +274,7 @@ using :file:`.copy()`:
 
 .. ipython:: python
 
-    red = RedBaron("stuff = 1 + 2\nprint 'Hello', stuff")
+    red = RedBaron("stuff = 1 + 2\nprint(stuff)")
     red
     i = red[0].value.copy()
     red[1].value = i
@@ -354,9 +354,9 @@ is intended as such, see the documentation for more information:
 
 .. ipython:: python
 
-    red = RedBaron("a = 1\n\nprint a")
+    red = RedBaron("a = 1\n\nprint(a)")
     red
-    red.insert(1, "if a:\n    print 'a == 1'")
+    red.insert(1, "if a:\n    print('a == 1')")
     red
 
 The important things to remember are that:

--- a/tests/test_initial_parsing.py
+++ b/tests/test_initial_parsing.py
@@ -548,24 +548,24 @@ def test_replace():
 
 
 def test_insert_before():
-    red = RedBaron("a = 1\nprint pouet\n")
+    red = RedBaron("a = 1\nprint(pouet)\n")
     red.print_.insert_before("chocolat")
-    assert red.dumps() == "a = 1\nchocolat\nprint pouet\n"
+    assert red.dumps() == "a = 1\nchocolat\nprint(pouet)\n"
 
 
 def test_insert_after():
-    red = RedBaron("a = 1\nprint pouet\n")
+    red = RedBaron("a = 1\nprint(pouet)\n")
     red.print_.insert_after("chocolat")
-    assert red.dumps() == "a = 1\nprint pouet\nchocolat\n"
+    assert red.dumps() == "a = 1\nprint(pouet)\nchocolat\n"
 
 
 def test_insert_before_offset():
-    red = RedBaron("a = 1\nprint pouet\n")
+    red = RedBaron("a = 1\nprint(pouet)\n")
     red.print_.insert_before("chocolat", offset=1)
-    assert red.dumps() == "chocolat\na = 1\nprint pouet\n"
+    assert red.dumps() == "chocolat\na = 1\nprint(pouet)\n"
 
 
 def test_insert_after_offset():
-    red = RedBaron("a = 1\nprint pouet\n")
+    red = RedBaron("a = 1\nprint(pouet)\n")
     red[0].insert_after("chocolat", offset=1)
-    assert red.dumps() == "a = 1\nprint pouet\nchocolat\n"
+    assert red.dumps() == "a = 1\nprint(pouet)\nchocolat\n"

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -2,7 +2,7 @@ from redbaron import RedBaron
 
 
 def test_mixmatch_with_redbaron_base_node_and_proxy_list_on_parent():
-    red = RedBaron("foo = 42\nprint 'bar'\n")
+    red = RedBaron("foo = 42\nprint('bar')\n")
     red.insert(0, "baz")
     assert red[0].on_attribute == "root"
     assert red[0].parent is red

--- a/utils/indentation_test.py
+++ b/utils/indentation_test.py
@@ -10,7 +10,7 @@ red = RedBaron(open("../redbaron.py", "r").read())
 def walk(node):
     if node is None:
         return
-    print [node.indentation, node]
+    print([node.indentation, node])
     for i in node._dict_keys:
         walk(getattr(node, i))
 
@@ -18,4 +18,4 @@ def walk(node):
         map(walk, getattr(node, i))
 
 map(walk, red)
-# print walk(red[0])
+# print(walk(red[0]))


### PR DESCRIPTION
Replace some "print 'Hello', x" with "print(x)" to have the same output
on Python 2 and Python 3.