### PR TITLE
Let Lexer guess good encoding on Node __str__

### DIFF
--- a/redbaron.py
+++ b/redbaron.py
@@ -945,9 +945,7 @@ class Node(GenericNodesUtils):
 
     def __str__(self):
         if runned_from_ipython():
-            return highlight(self.dumps(), PythonLexer(encoding="Utf-8"),
-                             Terminal256Formatter(style='monokai',
-                                                  encoding="Utf-8"))
+            return highlight(self.dumps(), PythonLexer(), Terminal256Formatter(style='monokai'))
         else:
             return self.dumps()
 


### PR DESCRIPTION
From issue #86, python3 under ipython and shell behaves differently. Merely because of PythonLexer being forced on utf-8.